### PR TITLE
#23 Simple Cell implementation

### DIFF
--- a/src/main/java/nock/model/Atom.java
+++ b/src/main/java/nock/model/Atom.java
@@ -20,11 +20,29 @@ public interface Atom extends Noun {
         return true;
     }
 
+    @Override
+    default Atom asAtom() {
+        return this;
+    }
+
+    @Override
+    default Cell asCell() {
+        throw new IllegalStateException("An Atom is not a Cell!");
+    }
+
     /**
      * Retrieves this atom's value as a {@link BigInteger}.
-     * @return Value
+     * @return Value as a {@link BigInteger}
      */
     BigInteger value();
+
+    /**
+     * Retrieves this atom's value as a long, if possible.
+     * @return Value as long
+     */
+    default long asLong() {
+        return this.value().longValueExact();
+    }
 
     /**
      * Returns a new Atom whose value is 1 more than the value of this

--- a/src/main/java/nock/model/AtomBigInteger.java
+++ b/src/main/java/nock/model/AtomBigInteger.java
@@ -13,36 +13,45 @@ import java.math.BigInteger;
  * @version $Id$
  * @since 1.0.0
  */
+@SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
 public final class AtomBigInteger implements Atom {
 
     /**
      * Value.
      */
-    private final BigInteger number;
+    private final BigInteger value;
 
     /**
      * Ctor.
-     * @param number Value
+     * Creates the Atom a = 0.
      */
-    public AtomBigInteger(final long number) {
-        this(BigInteger.valueOf(number));
+    public AtomBigInteger() {
+        this(0L);
     }
 
     /**
      * Ctor.
-     * @param number Value
+     * @param value Value
+     */
+    public AtomBigInteger(final long value) {
+        this(BigInteger.valueOf(value));
+    }
+
+    /**
+     * Ctor.
+     * @param value Value
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    public AtomBigInteger(final BigInteger number) {
-        if (number.compareTo(BigInteger.ZERO) < 0) {
+    public AtomBigInteger(final BigInteger value) {
+        if (value.compareTo(BigInteger.ZERO) < 0) {
             throw new IllegalArgumentException("Atoms are natural numbers");
         }
-        this.number = number;
+        this.value = value;
     }
 
     @Override
     public BigInteger value() {
-        return this.number;
+        return this.value;
     }
 
 }

--- a/src/main/java/nock/model/Cell.java
+++ b/src/main/java/nock/model/Cell.java
@@ -13,6 +13,21 @@ package nock.model;
  */
 public interface Cell extends Noun {
 
+    @Override
+    default boolean isAtom() {
+        return false;
+    }
+
+    @Override
+    default Atom asAtom() {
+        throw new IllegalStateException("A Cell is not an Atom!");
+    }
+
+    @Override
+    default Cell asCell() {
+        return this;
+    }
+
     /**
      * Cell's left side.
      * @return Noun
@@ -20,9 +35,41 @@ public interface Cell extends Noun {
     Noun left();
 
     /**
-     * Cell's right side.
+     * This Cell's right {@link Noun}.
      * @return Noun
      */
     Noun right();
+
+    /**
+     * This Cell's left {@link Atom}, if it's indeed one.
+     * @return Atom
+     */
+    default Atom leftAtom() {
+        return this.left().asAtom();
+    }
+
+    /**
+     * This Cell's left Cell, if it's indeed one.
+     * @return Atom
+     */
+    default Cell leftCell() {
+        return this.left().asCell();
+    }
+
+    /**
+     * This Cell's right {@link Atom}, if it's indeed one.
+     * @return Atom
+     */
+    default Atom rightAtom() {
+        return this.right().asAtom();
+    }
+
+    /**
+     * This Cell's right Cell, if it's indeed one.
+     * @return Cell
+     */
+    default Cell rightCell() {
+        return this.right().asCell();
+    }
 
 }

--- a/src/main/java/nock/model/CellSimple.java
+++ b/src/main/java/nock/model/CellSimple.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 Felipe Pina
+ *
+ * MIT License
+ */
+package nock.model;
+
+/**
+ * Simple implementation of {@link Cell}.
+ * @author Felipe Pina (felipe.pina@toptal.com)
+ * @version $Id$
+ * @since 1.0.0
+ */
+@SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+public final class CellSimple implements Cell {
+
+    /**
+     * This Cell's left noun.
+     */
+    private final Noun left;
+
+    /**
+     * This Cell's right noun.
+     */
+    private final Noun right;
+
+    /**
+     * Ctor.
+     * @param left Left noun
+     * @param right Right noun
+     */
+    public CellSimple(final Noun left, final Noun right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Noun left() {
+        return this.left;
+    }
+
+    @Override
+    public Noun right() {
+        return this.right;
+    }
+
+}

--- a/src/main/java/nock/model/Noun.java
+++ b/src/main/java/nock/model/Noun.java
@@ -19,4 +19,16 @@ public interface Noun {
      */
     boolean isAtom();
 
+    /**
+     * Attempts to cast this Noun into an {@link Atom}.
+     * @return Atom, if possible
+     */
+    Atom asAtom();
+
+    /**
+     * Attempts to cast this Noun into an {@link Cell}.
+     * @return Cell, if possible
+     */
+    Cell asCell();
+
 }

--- a/src/test/java/nock/model/AtomBigIntegerTest.java
+++ b/src/test/java/nock/model/AtomBigIntegerTest.java
@@ -26,14 +26,24 @@ public final class AtomBigIntegerTest {
     public final ExpectedException error = ExpectedException.none();
 
     /**
-     * Self-identifies as an Atom.
+     * Self-identifies as an {@link Atom}.
      */
     @Test
     public void selfIdentifiesAsAtom() {
         MatcherAssert.assertThat(
-            new AtomBigInteger(0L).isAtom(),
+            new AtomBigInteger().isAtom(),
             Matchers.is(true)
         );
+    }
+
+    /**
+     * Fails a cast to {@link Cell}.
+     */
+    @Test
+    public void failsCastToCell() {
+        this.error.expect(IllegalStateException.class);
+        this.error.expectMessage("An Atom is not a Cell!");
+        new AtomBigInteger().asCell();
     }
 
     /**
@@ -53,11 +63,11 @@ public final class AtomBigIntegerTest {
     @Test
     public void increments() {
         MatcherAssert.assertThat(
-            new AtomBigInteger(0L).increment().value().longValueExact(),
+            new AtomBigInteger(0L).increment().asLong(),
             Matchers.is(1L)
         );
         MatcherAssert.assertThat(
-            new AtomBigInteger(42L).increment().value().longValueExact(),
+            new AtomBigInteger(42L).increment().asLong(),
             Matchers.is(43L)
         );
     }

--- a/src/test/java/nock/model/AtomSuccessorTest.java
+++ b/src/test/java/nock/model/AtomSuccessorTest.java
@@ -19,7 +19,7 @@ import org.mockito.Mockito;
 public final class AtomSuccessorTest {
 
     /**
-     * Self-identifies as an Atom.
+     * Self-identifies as an {@link Atom}.
      */
     @Test
     public void selfIdentifiesAsAtom() {
@@ -36,17 +36,17 @@ public final class AtomSuccessorTest {
     @Test
     public void increments() {
         MatcherAssert.assertThat(
-            new AtomSuccessor(new AtomBigInteger(0L)).value().longValueExact(),
+            new AtomSuccessor(new AtomBigInteger(0L)).asLong(),
             Matchers.is(1L)
         );
         MatcherAssert.assertThat(
-            new AtomSuccessor(new AtomBigInteger(42L)).value().longValueExact(),
+            new AtomSuccessor(new AtomBigInteger(42L)).asLong(),
             Matchers.is(43L)
         );
         MatcherAssert.assertThat(
             new AtomSuccessor(
                 new AtomSuccessor(new AtomBigInteger(0L))
-            ).value().longValueExact(),
+            ).asLong(),
             Matchers.is(2L)
         );
     }

--- a/src/test/java/nock/model/CellSimpleTest.java
+++ b/src/test/java/nock/model/CellSimpleTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Felipe Pina
+ *
+ * MIT License
+ */
+package nock.model;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Tests for {@link CellSimple}.
+ * @author Felipe Pina (felipe.pina@toptal.com)
+ * @version $Id$
+ * @since 1.0.0
+ */
+public final class CellSimpleTest {
+
+    /**
+     * Junit expected exception.
+     */
+    @Rule
+    public final ExpectedException error = ExpectedException.none();
+
+    /**
+     * Self-identifies as a {@link Cell}.
+     */
+    @Test
+    public void selfIdentifiesAsCell() {
+        MatcherAssert.assertThat(
+            new CellSimple(new AtomBigInteger(), new AtomBigInteger()).isAtom(),
+            Matchers.is(false)
+        );
+    }
+
+    /**
+     * Fails a cast to {@link Atom}.
+     */
+    @Test
+    public void failsCastToAtom() {
+        this.error.expect(IllegalStateException.class);
+        this.error.expectMessage("A Cell is not an Atom!");
+        new CellSimple(new AtomBigInteger(), new AtomBigInteger()).asAtom();
+    }
+
+    /**
+     * Forms trees.
+     * @checkstyle MagicNumberCheck (40 lines)
+     */
+    @Test
+    public void formsTrees() {
+        final Cell tree = new CellSimple(
+            new CellSimple(
+                new AtomBigInteger(4L),
+                new AtomBigInteger(5L)
+            ),
+            new CellSimple(
+                new AtomBigInteger(6L),
+                new CellSimple(
+                    new AtomBigInteger(14L),
+                    new AtomBigInteger(15L)
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            tree.leftCell().leftAtom().asLong(),
+            Matchers.is(4L)
+        );
+        MatcherAssert.assertThat(
+            tree.leftCell().rightAtom().asLong(),
+            Matchers.is(5L)
+        );
+        MatcherAssert.assertThat(
+            tree.rightCell().leftAtom().asLong(),
+            Matchers.is(6L)
+        );
+        MatcherAssert.assertThat(
+            tree.rightCell().rightCell().leftAtom().asLong(),
+            Matchers.is(14L)
+        );
+        MatcherAssert.assertThat(
+            tree.rightCell().rightCell().rightAtom().asLong(),
+            Matchers.is(15L)
+        );
+    }
+
+}


### PR DESCRIPTION
For #23
- added CellSimple + unit tests
- added convenience method `Atom#asLong`
- added noun casts `Noun#asCell` and `Noun#asAtom`